### PR TITLE
fix : Make pyxcursor.py runnable on 64-bit as well as 32-bit platforms

### DIFF
--- a/pyxcursor/pyxcursor.py
+++ b/pyxcursor/pyxcursor.py
@@ -126,7 +126,8 @@ class Xcursor:
 
         bytearr = ctypes.cast(data.pixels, ctypes.POINTER(ctypes.c_ulong *height * width))[0]
         imgarray = np.array(bytearray(bytearr))
-        imgarray = imgarray.reshape(height,width,8)[:, :, (0, 1, 2, 3)]
+        imgarray = imgarray.reshape(height,width,
+                             ctypes.sizeof(ctypes.c_ulong))[:, :, (0, 1, 2, 3)]
         del bytearr
 
         return imgarray


### PR DESCRIPTION
Hi @zorvios, 

you did a great job with your little modue!
I needed the cursor image as part of a Qt for python program, that follows the mouse cursor with several copies of it.
It works great and fast enough. Thanks for that.

The only problem was, that my Raspberry Pi OS bullseye runs as a 32-bit OS on armv7 and ulong is 4 bytes on a 32-bit platform, not 8.
So, I changed the code to use the size of c_ulong, so that it works on my 32-bit platform and should do so on a 64-bit platform, as well. But I have not tested it on a 64-bit platform.

I hope you find my fix useful.

Kind regards